### PR TITLE
log.Fatal removal

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -3,11 +3,12 @@ package spatial
 import (
 	"bytes"
 	"io"
-	"log"
 	"math"
+
+	"github.com/pkg/errors"
 )
 
-func Decode(points string, precision int) []Point {
+func Decode(points string, precision int) ([]Point, error) {
 	var lat, lng int64
 
 	factor := math.Pow10(precision)
@@ -18,10 +19,10 @@ func Decode(points string, precision int) []Point {
 		dlat, _ := decodeInt(input)
 		dlng, err := decodeInt(input)
 		if err == io.EOF {
-			return path
+			return path, nil
 		}
 		if err != nil {
-			log.Fatal("unexpected err decoding polyline", err)
+			return nil, errors.Wrap(err, "unexpected error decoding polyline")
 		}
 
 		lat, lng = lat+dlat, lng+dlng

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -2,11 +2,9 @@ package spatial
 
 import (
 	"encoding/json"
-
-	_ "github.com/lib/pq"
-
 	"testing"
 
+	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,7 +25,8 @@ func TestPointEncodeExact(t *testing.T) {
 	assert.NotEqual(t, "", polyline)
 	assert.Equal(t, "km|~hAntmkfFsrNrmjA", polyline)
 
-	points := Decode(polyline, precision)
+	points, err := Decode(polyline, precision)
+	assert.NoError(t, err)
 	assert.Equal(t, path, points)
 }
 
@@ -58,7 +57,8 @@ func TestPointEncodingPrecisionRound(t *testing.T) {
 	assert.NotEqual(t, "", polyline)
 	assert.Equal(t, "ajxkFpgmcV}p@lpF", polyline)
 
-	points := Decode(polyline, precision)
+	points, err := Decode(polyline, precision)
+	assert.NoError(t, err)
 	assert.Equal(t, roundedPath, points)
 }
 

--- a/point_test.go
+++ b/point_test.go
@@ -37,8 +37,8 @@ func TestPointScanning(t *testing.T) {
 
 func TestScanNilPoint(t *testing.T) {
 	var np NullPoint
-	np.Scan(nil)
-
+	err := np.Scan(nil)
+	assert.NoError(t, err)
 	assert.False(t, np.Valid)
 }
 


### PR DESCRIPTION
This PR prevents the use of `log.Fatal` inside this package. Instead we return an error which can be handled properly by the caller of the function.